### PR TITLE
Fixed github theme bug #20

### DIFF
--- a/docs/base.css
+++ b/docs/base.css
@@ -23,6 +23,7 @@
   --font-color: rgb(17, 17, 17);
   --background-color: rgb(230, 216, 216);
   --logo-color: rgba(0, 0, 0, 0.658);
+  --github-color: rgb(0, 0, 0);
   background-color: var(--background-color);
   color: var(--font-color);
   --lb-header-bg-color: rgb(29, 29, 29);
@@ -37,6 +38,7 @@
   --background-color: rgb(34, 34, 34);
   --correct-word: rgb(255, 213, 73);
   --logo-color: rgba(255, 213, 73, 0.616);
+  --github-color: rgb(255, 213, 73);
   --lb-header-bg-color: rgb(255, 243, 230);
   --lb-header-color: rgb(24, 25, 26);
   --lb-list-item-bg-color: var(--lb-header-color);

--- a/docs/style.css
+++ b/docs/style.css
@@ -98,6 +98,10 @@ span {
   font-size: var(--font-size-small);
 }
 
+.footer > .links {
+  color:var(--github-color)
+}
+
 .container {
   position: absolute;
   top: 40vh;


### PR DESCRIPTION
Fixed #20 , now looks how it should. I have a question though. From .links style in CSS the github thingy has lower opacity and I think it would look better with a higher opacity. What do you think?
The contrast is enough for readability but it would look better with a higher one. If you want it then make another issue or just make your own PR.